### PR TITLE
Disable cache in the docker publish action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@ on:
   pull_request:
     branches: ["main"]
 
+  workflow_dispatch:
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: quay.io


### PR DESCRIPTION
We do this all the time. It's not worth it to keep the complexity
and cache on pull requests and not cache on merges/pushes.
